### PR TITLE
Fix broken action, add local testing so we don't have to test by pushing to GitHub and merging. 

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,16 +6,10 @@ on:
       - main
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,21 +35,8 @@ jobs:
         env:
           JEKYLL_ENV: production
       
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./_site
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site

--- a/README.md
+++ b/README.md
@@ -5,6 +5,30 @@ To run locally:
 - Start the server: `bundle exec jekyll serve`
 - Visit the site at [localhost:4000](http://localhost:4000)
 
+## Testing the Build
+
+Before pushing changes, you can test that the build process works locally:
+
+```bash
+./test-build.sh
+```
+
+This script:
+- Installs all dependencies (Ruby gems and npm packages)
+- Builds the Jekyll site with production settings
+- Verifies that Tailwind CSS is compiled correctly
+- Checks that the `_site` directory is generated
+
+Alternatively, you can run the build commands manually:
+
+```bash
+bundle install
+npm ci
+JEKYLL_ENV=production bundle exec jekyll build
+```
+
+The built site will be in the `_site/` directory.
+
 ## Deployment
 
 The site is automatically deployed to GitHub Pages via GitHub Actions when you push to the `main` branch. The workflow:

--- a/test-build.sh
+++ b/test-build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Test script to verify the build process works locally
+# This mimics what the GitHub Actions workflow does
+
+set -e  # Exit on error
+
+echo "🧪 Testing build process..."
+echo ""
+
+# Check if dependencies are installed
+echo "📦 Checking dependencies..."
+if ! command -v bundle &> /dev/null; then
+    echo "❌ Bundler not found. Please install Ruby and run: gem install bundler"
+    exit 1
+fi
+
+if ! command -v node &> /dev/null; then
+    echo "❌ Node.js not found. Please install Node.js"
+    exit 1
+fi
+
+# Install Ruby dependencies
+echo "📦 Installing Ruby dependencies..."
+bundle install
+
+# Install Node dependencies
+echo "📦 Installing Node dependencies..."
+npm ci
+
+# Build the site
+echo "🔨 Building Jekyll site..."
+JEKYLL_ENV=production bundle exec jekyll build
+
+# Check if build was successful
+if [ ! -d "_site" ]; then
+    echo "❌ Build failed: _site directory not found"
+    exit 1
+fi
+
+# Check if CSS was compiled
+if [ ! -f "_site/assets/css/main.css" ]; then
+    echo "❌ Build failed: CSS file not found"
+    exit 1
+fi
+
+# Check if CSS contains Tailwind classes (basic check)
+if ! grep -q "\.bg-primary" "_site/assets/css/main.css"; then
+    echo "⚠️  Warning: CSS file exists but may not contain Tailwind classes"
+    echo "   This might be okay if you're not using those classes, but worth checking"
+else
+    echo "✅ Tailwind CSS classes found in compiled CSS"
+fi
+
+echo ""
+echo "✅ Build successful!"
+echo "📁 Built site is in: _site/"
+echo "🌐 You can preview it with: bundle exec jekyll serve"


### PR DESCRIPTION
## Fix GitHub Pages deployment and add local testing

### Problem
After merging the previous PR, the deployment failed with a 422 (Validation Failed) error. The newer GitHub Actions Pages deployment method requires repository settings changes that weren't configured, causing the deployment step to fail.

### Changes

**GitHub Actions Workflow (`.github/workflows/github-pages.yml`)**
- Switched from newer `deploy-pages` action to `peaceiris/actions-gh-pages` action
- This deploys to the `gh-pages` branch, which works with default GitHub Pages settings
- Simplified to a single job (build-and-deploy) for better reliability
- No repository settings changes required

**Local Testing (`test-build.sh`)**
- Added a test script to verify the build process works locally
- Checks dependencies, installs packages, builds the site, and verifies Tailwind CSS compilation
- Allows testing before pushing to avoid failed deployments

**README.md**
- Added "Testing the Build" section with instructions
- Documents both the test script and manual build commands
- Helps developers verify changes work before pushing

### Impact
- **Fixes deployment**: Workflow now works with default GitHub Pages settings
- **No configuration needed**: Works out of the box without changing repository settings
- **Better developer experience**: Can test builds locally before pushing
- **More reliable**: Uses well-established `peaceiris` action that's widely used

### Testing
The workflow should now:
1. Build successfully (as verified by the test script)
2. Deploy to `gh-pages` branch automatically
3. Serve the site on GitHub Pages

You can test locally before pushing by running `./test-build.sh`.