### PR TITLE
Clean up _config.yml: add exclude list, remove tailwind include

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,23 +65,18 @@ toc:
 tag_page_layout: tag
 tag_page_dir: tag
 
-include: ["node_modules/tailwindcss"]
-# Exclude from processing.
-# The following items will not be processed, by default.
-# Any item listed under the `exclude:` key here will be automatically added to
-# the internal "default list".
-#
-# Excluded items can be processed by explicitly listing the directories or
-# their entries' file path in the `include:` list.
-#
-# exclude:
-#   - .sass-cache/
-#   - .jekyll-cache/
-#   - gemfiles/
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules/
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/
+  - package.json
+  - package-lock.json
+  - postcss.config.js
+  - tailwind.config.js
+  - test-build.sh
+  - README.md
+  - .github/


### PR DESCRIPTION
## Summary
- Remove `include: ["node_modules/tailwindcss"]` since Tailwind is only needed at build time by PostCSS, not in the deployed output
- Add proper `exclude` list to prevent source files (`package.json`, `tailwind.config.js`, `postcss.config.js`, `test-build.sh`, etc.) from being served in the deployed site
- Part of the fix for GitHub Pages deployment — pairs with configuring `spoonme.kitchen` as the custom domain

## Test plan
- [ ] Run `JEKYLL_ENV=production bundle exec jekyll build` and verify `_site/` no longer contains stray source files
- [ ] Confirm GitHub Actions workflow completes successfully after merge
- [ ] Verify `spoonme.kitchen` loads with correct styles after custom domain is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)